### PR TITLE
Some of sizeof() bugs fixed.

### DIFF
--- a/src/editlev.cc
+++ b/src/editlev.cc
@@ -76,10 +76,10 @@ char *find_level (const char *name_given)
         char *name1 = (char *) malloc (7);
         char *name2 = (char *) malloc (6);
         if (n > 99)
-            snprintf (name1, sizeof(name1), "E%dM%02d", n / 100, n % 100);
+            sprintf (name1, "E%dM%02d", n / 100, n % 100);
         else
-            snprintf (name1, sizeof(name1), "E%dM%d", n / 10, n % 10);
-        snprintf (name2, sizeof(name2), "MAP%02d", n);
+            sprintf (name1, "E%dM%d", n / 10, n % 10);
+        sprintf (name2, "MAP%02d", n);
         int match1 = FindMasterDir (MasterDir, name1) != NULL;
         int match2 = FindMasterDir (MasterDir, name2) != NULL;
         if (match1 && ! match2)       // Found only ExMy

--- a/src/editsave.cc
+++ b/src/editsave.cc
@@ -218,7 +218,7 @@ char *GetWadFileName (const char *levelname)
       al_fbase_t base;
 
       al_fana (wf->filename, drv, path, base, 0);
-      snprintf (wf->filename, strlen(wf->filename), "%s%s%s.bak", drv, path, base);
+      snprintf (wf->filename, strlen(wf->filename) + 1, "%s%s%s.bak", drv, path, base);
       verbmsg ("setting wf->filename to %s\n", wf->filename);  // DEBUG
       /* Need to close, then reopen: problems with SHARE.EXE */
       verbmsg ("closing %p\n", wf->fp);				// DEBUG


### PR DESCRIPTION
You cannot call sizeof() for dynamically allocated memory. It will just return the size of pointer, not the size of allocation.

Also strlen() counts only characters, while size parameter of snprintf() also counts the final null byte.
